### PR TITLE
Add pm5 support

### DIFF
--- a/virion.yml
+++ b/virion.yml
@@ -3,3 +3,4 @@ version: 0.0.2
 antigen: pjz9n\advancedform
 api:
   - 4.0.0
+  - 5.0.0


### PR DESCRIPTION
PocketMine-MP 5 does not make any BC break changes to `Form`, and adding the API version to `virion.yml` seems to be sufficient.