### PR TITLE
Fix obsolete function `stupid_json_decode`

### DIFF
--- a/src/pjz9n/advancedform/chain/FormChainListener.php
+++ b/src/pjz9n/advancedform/chain/FormChainListener.php
@@ -87,6 +87,7 @@ final class FormChainListener implements Listener
     }
 
     /**
+     * @throws ReflectionException
      * @throws PacketHandlingException
      */
     public function onReceiveForm(DataPacketReceiveEvent $event): void


### PR DESCRIPTION
This PR is a follow-up to the changes mentioned at https://github.com/PJZ9n/AdvancedForm/pull/4#issuecomment-1656826552.
As noted in [the comment afterwards](https://github.com/PJZ9n/AdvancedForm/pull/4#issuecomment-1663569398), this destructive change is applied whether using PM4 or PM5, and should be merged into `master` and `pm5` branches.
(To begin with, I don't think it is necessary to separate the branches since no API changes have occurred between pm4 and pm5.)
