### PR TITLE
CustomForm: メッセージの個数分 Label 要素を生成するように

### DIFF
--- a/src/pjz9n/advancedform/custom/CustomForm.php
+++ b/src/pjz9n/advancedform/custom/CustomForm.php
@@ -348,7 +348,7 @@ abstract class CustomForm extends FormBase
         }
         return [
             "content" => array_merge(
-                count($this->messages) <= 0 ? [] : [new Label(implode(TextFormat::EOL, array_map(fn(string $message): string => $message . TextFormat::RESET, $this->messages)))],
+				array_map(fn(string $message): Label => new Label($message), $this->messages),
                 $elements,
             ),
         ];

--- a/src/pjz9n/advancedform/custom/CustomForm.php
+++ b/src/pjz9n/advancedform/custom/CustomForm.php
@@ -348,7 +348,7 @@ abstract class CustomForm extends FormBase
         }
         return [
             "content" => array_merge(
-				array_map(fn(string $message): Label => new Label($message), $this->messages),
+                array_map(fn(string $message): Label => new Label($message), $this->messages),
                 $elements,
             ),
         ];


### PR DESCRIPTION
# PRの目的
二つ以上のメッセージを持った CustomForm の検証時にエラーが発生する問題を修正します。

# 問題の再現方法
エラーは以下のようなコードで再現可能です。
```php
$form = CallbackCustomForm::create("")->appendMessages(["a", "b"]);
$player->sendForm($form);
```
出力されるエラー:
```
[17:05:38.544] [Server thread/CRITICAL]: [Player: Nerahikada] Failed to validate form pjz9n\advancedform\custom\CallbackCustomForm: Expected 2 response(s), got 1 response(s)
[17:05:38.544] [Server thread/CRITICAL]: pocketmine\form\FormValidationException: "Expected 2 response(s), got 1 response(s)" (EXCEPTION) in "virions/AdvancedForm/src/pjz9n/advancedform/custom/CustomForm" at line 278
```

# このPRの背景
カスタムフォームの応答の検証時には、メッセージの個数分が足された要素数を期待しますが
https://github.com/PJZ9n/AdvancedForm/blob/402b9cd0bd4ad54650284b9fb766af55abaa9b6e/src/pjz9n/advancedform/custom/CustomForm.php#L276
(ここも同様)
https://github.com/PJZ9n/AdvancedForm/blob/402b9cd0bd4ad54650284b9fb766af55abaa9b6e/src/pjz9n/advancedform/custom/CustomForm.php#L283
実際にプレイヤーに送信されるのは一つの Label 要素だけです。
https://github.com/PJZ9n/AdvancedForm/blob/402b9cd0bd4ad54650284b9fb766af55abaa9b6e/src/pjz9n/advancedform/custom/CustomForm.php#L351

この問題を修正するためにはどちらかの仕様に合わせればよいわけですが、
- 修正量が少ない
- Label 要素の下には空白が挿入されるため、(大量のメッセージがある場合などに)読みやすさの向上が期待できる

という点から複数の Label 要素を作成するよう変更しました。