### PR TITLE
ModalFormが閉じられた際にFormValidationExceptionが発生する問題を修正

### DIFF
--- a/src/pjz9n/advancedform/modal/CallbackModalForm.php
+++ b/src/pjz9n/advancedform/modal/CallbackModalForm.php
@@ -45,7 +45,7 @@ class CallbackModalForm extends ModalForm
         string   $title,
         string   $text,
         ?Closure $handleSelect = null,
-        ?Closure $handleClose = null
+        ?Closure $handleClose = null,
     ): self
     {
         if ($handleSelect !== null) {
@@ -78,7 +78,7 @@ class CallbackModalForm extends ModalForm
         string             $title,
         string             $text,
         protected ?Closure $handleSelect = null,
-        protected ?Closure $handleClose = null
+        protected ?Closure $handleClose = null,
     )
     {
         if ($this->handleSelect !== null) {
@@ -143,6 +143,4 @@ class CallbackModalForm extends ModalForm
             ($this->handleClose)($player);
         }
     }
-
-
 }

--- a/src/pjz9n/advancedform/modal/CallbackModalForm.php
+++ b/src/pjz9n/advancedform/modal/CallbackModalForm.php
@@ -42,6 +42,7 @@ class CallbackModalForm extends ModalForm
         string   $title,
         string   $text,
         ?Closure $handleSelect = null,
+        ?Closure $handleClose = null
     ): self
     {
         if ($handleSelect !== null) {
@@ -50,7 +51,13 @@ class CallbackModalForm extends ModalForm
             // @formatter:on
         }
 
-        return new self($title, $text, $handleSelect);
+        if ($handleClose !== null) {
+            // @formatter:off
+            Utils::validateCallableSignature(function (Player $player): void {}, $handleClose);
+            // @formatter:on
+        }
+
+        return new self($title, $text, $handleSelect, $handleClose);
     }
 
     /**
@@ -58,18 +65,27 @@ class CallbackModalForm extends ModalForm
      * @param string $text Message text to display on the form
      * @param Closure|null $handleSelect Called when the button is selected
      * @phpstan-param Closure(Player, ModalFormResponse): void|null $handleSelect
+     * @phpstan-param Closure(Player): void|null $handleClose
      *
      * @see ModalForm::handleSelect()
+     * @see ModalForm::handleClose()
      */
     public function __construct(
         string             $title,
         string             $text,
         protected ?Closure $handleSelect = null,
+        protected ?Closure $handleClose = null
     )
     {
         if ($this->handleSelect !== null) {
             // @formatter:off
             Utils::validateCallableSignature(function (Player $player, ModalFormResponse $response): void {}, $this->handleSelect);
+            // @formatter:on
+        }
+
+        if ($this->handleClose !== null) {
+            // @formatter:off
+            Utils::validateCallableSignature(function (Player $player): void {}, $this->handleClose);
             // @formatter:on
         }
 
@@ -93,10 +109,36 @@ class CallbackModalForm extends ModalForm
         return $this;
     }
 
+    /**
+     * @phpstan-return Closure(Player): void|null
+     */
+    public function getHandleClose(): ?Closure
+    {
+        return $this->handleClose;
+    }
+
+    /**
+     * @phpstan-param Closure(Player): void|null $handleClose
+     */
+    public function setHandleClose(?Closure $handleClose): self
+    {
+        $this->handleClose = $handleClose;
+        return $this;
+    }
+
     protected function handleSelect(Player $player, ModalFormResponse $response): void
     {
         if ($this->handleSelect !== null) {
             ($this->handleSelect)($player, $response);
         }
     }
+
+    protected function handleClose(Player $player): void
+    {
+        if ($this->handleClose !== null) {
+            ($this->handleClose)($player);
+        }
+    }
+
+
 }

--- a/src/pjz9n/advancedform/modal/CallbackModalForm.php
+++ b/src/pjz9n/advancedform/modal/CallbackModalForm.php
@@ -34,9 +34,12 @@ class CallbackModalForm extends ModalForm
      * @param string $title Form title
      * @param string $text Message text to display on the form
      * @param Closure|null $handleSelect Called when the button is selected
+     * @param Closure|null $handleClose Called when the form is closed
      * @phpstan-param Closure(Player, ModalFormResponse): void|null $handleSelect
+     * @phpstan-param Closure(Player): void|null $handleClose
      *
      * @see ModalForm::handleSelect()
+     * @see ModalForm::handleClose()
      */
     public static function create(
         string   $title,
@@ -64,6 +67,7 @@ class CallbackModalForm extends ModalForm
      * @param string $title Form title
      * @param string $text Message text to display on the form
      * @param Closure|null $handleSelect Called when the button is selected
+     * @param Closure|null $handleClose Called when the form is closed
      * @phpstan-param Closure(Player, ModalFormResponse): void|null $handleSelect
      * @phpstan-param Closure(Player): void|null $handleClose
      *

--- a/src/pjz9n/advancedform/modal/ModalForm.php
+++ b/src/pjz9n/advancedform/modal/ModalForm.php
@@ -100,7 +100,7 @@ abstract class ModalForm extends FormBase
     {
         if ($data === null) {
             $this->handleClose($player);
-        } else if (!is_bool($data)) {
+        } else if (is_bool($data)) {
             $selectedButton = $data ? $this->yesButton : $this->noButton;
             $handler = $selectedButton->getHandler();
             if ($handler === null || (!$handler->handle($this, $selectedButton, $player))) {

--- a/src/pjz9n/advancedform/modal/ModalForm.php
+++ b/src/pjz9n/advancedform/modal/ModalForm.php
@@ -98,13 +98,16 @@ abstract class ModalForm extends FormBase
 
     final public function handleResponse(Player $player, $data): void
     {
-        if (!is_bool($data)) {
+        if ($data === null) {
+            $this->handleClose($player);
+        } else if (!is_bool($data)) {
+            $selectedButton = $data ? $this->yesButton : $this->noButton;
+            $handler = $selectedButton->getHandler();
+            if ($handler === null || (!$handler->handle($this, $selectedButton, $player))) {
+                $this->handleSelect($player, new ModalFormResponse($selectedButton, $data));
+            }
+        } else {
             throw new FormValidationException("Expected bool, got " . gettype($data));
-        }
-        $selectedButton = $data ? $this->yesButton : $this->noButton;
-        $handler = $selectedButton->getHandler();
-        if ($handler === null || (!$handler->handle($this, $selectedButton, $player))) {
-            $this->handleSelect($player, new ModalFormResponse($selectedButton, $data));
         }
     }
 
@@ -113,6 +116,14 @@ abstract class ModalForm extends FormBase
      * NOTE: This will not be called if successfully processed by ButtonHandler!
      */
     protected function handleSelect(Player $player, ModalFormResponse $response): void
+    {
+        //NOOP
+    }
+
+    /**
+     * Called when the form is closed
+     */
+    protected function handleClose(Player $player): void
     {
         //NOOP
     }

--- a/src/pjz9n/advancedform/modal/ModalForm.php
+++ b/src/pjz9n/advancedform/modal/ModalForm.php
@@ -107,7 +107,7 @@ abstract class ModalForm extends FormBase
                 $this->handleSelect($player, new ModalFormResponse($selectedButton, $data));
             }
         } else {
-            throw new FormValidationException("Expected bool, got " . gettype($data));
+            throw new FormValidationException("Expected bool or null, got " . gettype($data));
         }
     }
 


### PR DESCRIPTION
ModalFormは閉じられるとNULLが返却されるため、  
`handleClose` を追加することにより、FormValidationExceptionが発生する  
問題を修正します

## エラーの再現方法
以下のコードを実行した後、フォームをエスケープキーなどで閉じることで再現できます。

```php
$form = CallbackModalForm::create("", "");
$player->sendForm($form);
```
エラー内容
```text
[22:21:04.958] [Server thread/CRITICAL]: [Player: Lyrica0954] Failed to validate form pjz9n\advancedform\custom\CallbackModalForm: Excepted bool, got NULL
[22:21:04.959] [Server thread/CRITICAL]: pocketmine\form\FormValidationException: "Excepted bool, got NULL" (EXCEPTION) in "PocketMine-MP/virions/AdvancedForm/src/pjz9n/advancedform/modal/ModalForm" at line 102
```

## 変更点
以下のメソッドを追加しました。
- `ModalForm->handleClose(Player $player): void`

`CallbackModalForm` に `handleClose` のコールバックを追加しました。