### PR TITLE
Remove duplicate codes

### DIFF
--- a/src/pjz9n/advancedform/custom/CallbackCustomForm.php
+++ b/src/pjz9n/advancedform/custom/CallbackCustomForm.php
@@ -47,17 +47,6 @@ class CallbackCustomForm extends CustomForm
         array    $elements = [],
     ): self
     {
-        if ($handleSubmit !== null) {
-            // @formatter:off
-            Utils::validateCallableSignature(function (Player $player, CustomFormResponse $response): void {}, $handleSubmit);
-            // @formatter:on
-        }
-        if ($handleClose !== null) {
-            // @formatter:off
-            Utils::validateCallableSignature(function (Player $player): void {}, $handleClose);
-            // @formatter:on
-        }
-
         return new self($title, $handleSubmit, $handleClose, $elements);
     }
 

--- a/src/pjz9n/advancedform/menu/CallbackMenuForm.php
+++ b/src/pjz9n/advancedform/menu/CallbackMenuForm.php
@@ -52,17 +52,6 @@ class CallbackMenuForm extends MenuForm
         array    $buttons = [],
     ): self
     {
-        if ($handleSelect !== null) {
-            // @formatter:off
-            Utils::validateCallableSignature(function (Player $player, MenuFormResponse $response): void {}, $handleSelect);
-            // @formatter:on
-        }
-        if ($handleClose !== null) {
-            // @formatter:off
-            Utils::validateCallableSignature(function (Player $player): void {}, $handleClose);
-            // @formatter:on
-        }
-
         return new self($title, $text, $handleSelect, $handleClose, $buttons);
     }
 

--- a/src/pjz9n/advancedform/modal/CallbackModalForm.php
+++ b/src/pjz9n/advancedform/modal/CallbackModalForm.php
@@ -48,18 +48,6 @@ class CallbackModalForm extends ModalForm
         ?Closure $handleClose = null,
     ): self
     {
-        if ($handleSelect !== null) {
-            // @formatter:off
-            Utils::validateCallableSignature(function (Player $player, ModalFormResponse $response): void {}, $handleSelect);
-            // @formatter:on
-        }
-
-        if ($handleClose !== null) {
-            // @formatter:off
-            Utils::validateCallableSignature(function (Player $player): void {}, $handleClose);
-            // @formatter:on
-        }
-
         return new self($title, $text, $handleSelect, $handleClose);
     }
 


### PR DESCRIPTION
Since the signatures are verified by the constructor, these codes can be removed.